### PR TITLE
Update runner container definition to match upstream

### DIFF
--- a/build-cluster/github-runner-deployment.yaml
+++ b/build-cluster/github-runner-deployment.yaml
@@ -21,8 +21,10 @@ spec:
           volumeMounts:
             - mountPath: /runner/_work
               name:      work
-            - mountPath: /var/run
-              name:      docker
+            - mountPath: /runner/externals
+              name:      externals
+            - mountPath: /certs/client
+              name:      certs-client
             - mountPath: /lib/modules
               name:      modules
               readOnly:  true
@@ -36,8 +38,10 @@ spec:
           volumeMounts:
             - mountPath: /runner/_work
               name:      work
-            - mountPath: /var/run
-              name:      docker
+            - mountPath: /runner/externals
+              name:      externals
+            - mountPath: /certs/client
+              name:      certs-client
             - mountPath: /lib/modules
               name:      modules
               readOnly:  true


### PR DESCRIPTION
The upstream runner has switched from a shared unix socket in an emptyDir to a localhost tcp socket
New externals and certs-clients mounts have also been added to facilitate the tcp connection